### PR TITLE
normalized priors

### DIFF
--- a/stan/tweet_sirtd_negbin_ODE.stan
+++ b/stan/tweet_sirtd_negbin_ODE.stan
@@ -76,8 +76,8 @@ model {
   omega ~ normal(prior_omega_mean, prior_omega_std);
   dI ~ normal(prior_dI_mean, prior_dI_std);
   dT ~ normal(prior_dT_mean, prior_dT_std);
-  phi_inv ~ exponential(5);
-  phi_twitter_inv ~ exponential(5);
+  phi_inv ~ exponential(1);
+  phi_twitter_inv ~ exponential(1);
   twitter_rate ~ exponential(prior_twitter_lambda);
 
   if (compute_likelihood == 1){


### PR DESCRIPTION
As we've discussed I've normalized the priors across models.

All of `baseline` priors for "dispersion" parameters for `tweets` and `deaths` are propagated to `sirtd` model.

I've incorporated the `lambda_twitter` as `exponential` from `sirtd` to the `baseline` model.

Also my VS Code linter removed several whitespaces automatically. So that's why there is tons of changes.